### PR TITLE
split job-specific spec from common metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - colorized output for job status
 - generate friendlier names for command jobs
 - generate friendlier names for file jobs
+- internally centralise handling of common fields like `"name"`
 
 ## [0.1.6] - 2020-03-13
 

--- a/src/lib/jobs/command.rs
+++ b/src/lib/jobs/command.rs
@@ -16,8 +16,6 @@ lazy_static! {
 #[derive(Debug, Deserialize, PartialEq, Serialize)]
 #[serde(rename_all = "lowercase", tag = "type")]
 pub struct Command {
-    pub name: Option<String>,
-    pub needs: Option<Vec<String>>,
     pub argv: Option<Vec<String>>,
     pub chdir: Option<PathBuf>,
     pub command: String,
@@ -27,8 +25,6 @@ pub struct Command {
 impl Default for Command {
     fn default() -> Self {
         Command {
-            name: None,
-            needs: None,
             argv: None,
             chdir: None,
             command: String::new(),

--- a/src/lib/jobs/file.rs
+++ b/src/lib/jobs/file.rs
@@ -405,7 +405,6 @@ mod tests {
             path: file_old.path,
             src: Some(src.clone()),
             state: FileState::Link,
-            ..Default::default()
         };
 
         fs_write(&src, "hello")?;
@@ -430,7 +429,6 @@ mod tests {
             path: temp_file()?.to_path_buf(),
             src: Some(src.clone()),
             state: FileState::Link,
-            ..Default::default()
         };
 
         fs_write(&src, "hello")?;
@@ -456,7 +454,6 @@ mod tests {
             path: temp_dir()?.to_path_buf(),
             src: Some(src.clone()),
             state: FileState::Link,
-            ..Default::default()
         };
 
         fs_write(&src, "hello")?;
@@ -567,7 +564,6 @@ mod tests {
             path: PathBuf::from("foo"),
             src: Some(PathBuf::from("bar")),
             state: FileState::Link,
-            ..Default::default()
         };
         let got = file.name();
         let want = "ln -sf bar foo";

--- a/src/lib/jobs/file.rs
+++ b/src/lib/jobs/file.rs
@@ -59,8 +59,6 @@ pub enum FileState {
 #[derive(Debug, Deserialize, PartialEq, Serialize)]
 #[serde(rename_all = "lowercase", tag = "type")]
 pub struct File {
-    pub name: Option<String>,
-    pub needs: Option<Vec<String>>,
     pub force: Option<bool>,
     pub path: PathBuf,
     pub src: Option<PathBuf>,
@@ -69,8 +67,6 @@ pub struct File {
 impl Default for File {
     fn default() -> Self {
         Self {
-            name: None,
-            needs: None,
             force: None,
             path: PathBuf::new(),
             src: None,


### PR DESCRIPTION
### Changed

- internally centralise handling of common fields like `"name"`