### PR TITLE
escape path expressions results for valid TOML

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- escape path expressions so Windows paths are valid TOML (#17)
+
 ## [0.1.7] - 2020-04-06
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -731,6 +731,7 @@ dependencies = [
  "dirs 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "mktemp 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
  "subprocess 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "tera 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ colored = "1"
 dirs = "2"
 lazy_static = "1"
 mktemp = "0.4"
+regex = "1"
 serde = { version = "1", features = ["derive"] }
 subprocess = "0.1"
 tera = { version = "1", default-features = false }


### PR DESCRIPTION
### Fixed

- escape path expressions so Windows paths are valid TOML ( fixes #17)